### PR TITLE
[Server] / #28 / 그룹삭제시 연관된 도큐멘트 삭제 관련

### DIFF
--- a/server/src/modules/group/group.controller.ts
+++ b/server/src/modules/group/group.controller.ts
@@ -10,15 +10,21 @@ import {
   HttpStatus,
   InternalServerErrorException,
   Body,
+  UseInterceptors,
+  UploadedFile,
 } from "@nestjs/common";
 import { InjectConnection } from "@nestjs/mongoose";
 import { Connection } from "mongoose";
+import { Response } from "express";
+import { FileInterceptor } from "@nestjs/platform-express";
+import { extname } from "path";
+import { diskStorage } from "multer";
+
 import { GroupService } from "./group.service";
 import { Group } from "src/entities/group.entity";
 import { GetGroup } from "src/commons/decorator.dto";
 import { CreateConditionDto } from "./dto/createCondition.dto";
 import { UpdateConditionDto } from "./dto/updateCondition.dto";
-import { Response } from "express";
 
 @Controller("group")
 export class GroupController {
@@ -283,4 +289,30 @@ export class GroupController {
       await session.endSession();
     }
   }
+
+  // 멤버 정보가 담긴 csv파일을 읽어서 디비에 저장하기
+  // @Post("member/upload/:groupId")
+  // @UseInterceptors(
+  //   FileInterceptor("csv", {
+  //     storage: diskStorage({
+  //       destination: "./csv",
+  //       filename: (req, file, cb) => {
+  //         const randomName = Array(32)
+  //           .fill(null)
+  //           .map(() => Math.round(Math.random() * 16).toString(16))
+  //           .join("");
+  //         cb(null, `${randomName}${extname(file.originalname)}`);
+  //       },
+  //     }),
+  //   }),
+  // )
+  // async pushToMemeber(
+  //   @Headers("Authorization") authorization: string,
+  //   @Param("groupId") groupId: string,
+  //   @UploadedFile() file: Express.Multer.File,
+  //   @Res() res: any,
+  // ) {
+  //   await this.groupService.pushToMember(file);
+  //   return res.send("OK");
+  // }
 }

--- a/server/src/modules/group/group.service.ts
+++ b/server/src/modules/group/group.service.ts
@@ -91,6 +91,7 @@ export class GroupService {
       const { _id }: any = await this.authRepository.validateToken(auth);
       // 해당 유저가 갖고 있는 유저의 해당 그룹 아이디 정보 삭제
       await this.userRepository.removeGroupFromUser(_id, groupId);
+
       // 해당 그룹이 갖고 있는 스케쥴을 삭제하기 위해 그룹 도큐먼트에서 스켸쥴 아이디만 조회
       const { schedules }: any =
         await this.groupRepository.getScheduleIdFromGroup(groupId);

--- a/server/src/repositories/group.repository.ts
+++ b/server/src/repositories/group.repository.ts
@@ -67,7 +67,7 @@ export class GroupRepository {
     await this.groupModel.updateOne(
       { _id: id },
       {
-        $pull: { schedules: { _id: scheduleId } },
+        $pullAll: { schedules: [scheduleId] },
       },
     );
   }

--- a/server/src/repositories/user.repository.ts
+++ b/server/src/repositories/user.repository.ts
@@ -88,8 +88,9 @@ export class UserRepository {
     await this.userModel.updateOne(
       { _id },
       {
-        $pull: { groups: { _id: groupId } },
+        $pullAll: { groups: [groupId] },
       },
+      { new: true },
     );
   }
   // 유저의 비밀번호 가져오기 - 비밀번호 일치


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경사항
- 그룹 삭제시 해당 그룹을 소유한 유저의 그룹 아이디도 삭제 안 되는 부분 코드 수정
- 스케쥴 삭제시 해당 스케쥴을 소유한 그룹의 스케쥴도 삭제 안 되는 부분 코드 수정

### 변경된 코드 부분
```ts
// userRepository.ts
async removeGroupFromUser(_id: any, groupId: string) {
    await this.userModel.updateOne(
      { _id },
      {
        //변경전 코드:  $pull: {groups: { _id: groupId}}
        $pullAll: { groups: [groupId] }, 
      },
      { new: true },
    );
  }
```
